### PR TITLE
Adapted the queens module to fix open issues

### DIFF
--- a/Bot/Component/Impl/Queens.hs
+++ b/Bot/Component/Impl/Queens.hs
@@ -32,4 +32,4 @@ safe (x:xs) = and (map (\f -> safeDiag (f) (f x 1) xs) [ (+), (-) ])
 safeDiag :: ( Int -> Int -> Int ) -> Int -> [Int] -> Bool
 safeDiag _ _ [] = True
 safeDiag f field (x:xs) = field /= x && safeDiag f y xs
-  where y = f x 1
+  where y = f field 1

--- a/Bot/Component/Impl/Queens.hs
+++ b/Bot/Component/Impl/Queens.hs
@@ -11,12 +11,15 @@ import Data.Char
 import Data.List
 
 calcQueens :: Bot Component
-calcQueens = command "!queens" setQueens
+calcQueens = command "!queens" $ sendEach . setQueens
     where
-        setQueens = (ircReplyMaybe =<<) . queen . takeWhile isDigit . unwords
+        sendEach = mapM_ ircReply
+        setQueens = queen . takeWhile isDigit . unwords
 
-queen :: String -> Bot ( Maybe String )
-queen a = liftM ( Just . show ) $ return $ head $ foldM foldingFunction [] [1..n]
+queen :: String -> [String]
+queen a
+        | n > 25 = return "I better not shoot myself by answering that!"
+        | otherwise = prettify $ getResult result
    where
       -- Our folding function. It works like this:
       -- list: a list of already known safe positions from the previous fold
@@ -24,6 +27,20 @@ queen a = liftM ( Just . show ) $ return $ head $ foldM foldingFunction [] [1..n
       -- The function itself returns a list of lists, with the inner lists each having a position prepended that is safe
       foldingFunction list _ = [x:list | x <- [1..n] \\ list, safe (x:list)]
       n = read a :: Int
+      result = foldM foldingFunction [] [1..n]
+
+prettify :: [Int] -> [String]
+prettify [] = ["There is no solution for that."]
+prettify list
+        | length list > 12 = (show list):[]
+        | otherwise = (show list):(map prettyRow list)
+    where
+        prettyRow x = (concat . replicate (x-1)) ". " ++ "Q " ++ (concat . replicate (n-x)) ". "
+        n = length list
+
+getResult :: [[Int]] -> [Int]
+getResult [] = []
+getResult (x:_) = x
 
 safe :: [Int] -> Bool
 safe [] = True


### PR DESCRIPTION
These two commits target the issues numberten/zhenya_bot#19 and numberten/zhenya_bot#20 as well as a bug which was noticed during development.

The bot should now friendly decline calculating boards with more than 25 rows/columns.

For boards smaller than 13 it should also print the board itself in addition to the list.

If there are no solutions, the bot answers that too.

If there is anything not "haskelly", let me know too!
